### PR TITLE
temporary file location

### DIFF
--- a/pdf.go
+++ b/pdf.go
@@ -44,7 +44,7 @@ func (r *RequestPdf) ParseTemplate(templateFileName string, data interface{}) er
 
 //GeneratePDF generates the pdf from the request
 func (r *RequestPdf) GeneratePDF(pdfPath string) error {
-	f, err := ioutil.TempFile(".", "html2pdf*.html")
+	f, err := ioutil.TempFile("", "html2pdf*.html")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use `os.TempDir` for temporary file location instead of the current directory, which could be not accessible from the current user.